### PR TITLE
Minor typo fixes

### DIFF
--- a/sample.tex
+++ b/sample.tex
@@ -90,7 +90,7 @@
 
 % committee member names
 \advisor{Advisor Name}
-\coadvisor{Co-Adivisor Name} % co-advisor is optional
+\coadvisor{Co-Advisor Name} % co-advisor is optional
 \committee{First Member} % as many committee entries as you need
 \committee{Second Member}
 \committee{Third Member}
@@ -143,7 +143,7 @@ This document aims to get you started typesetting your thesis or dissertation in
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \acknowledgements{%
-I would like to thank the CSU Graduate Student Council for iniaiting and supporting the creation of this project and the CSU Graduate School for their assistance and feedback.  Thank you to CSU for being awsome, to the creators of \LaTeX{} for making a great typesetting tool and to everyone who has contributed to this template.  You may replace this text with your own acknowledgements.
+I would like to thank the CSU Graduate Student Council for initiating and supporting the creation of this project and the CSU Graduate School for their assistance and feedback.  Thank you to CSU for being awesome, to the creators of \LaTeX{} for making a great typesetting tool and to everyone who has contributed to this template.  You may replace this text with your own acknowledgements.
 }
 
 % Metadata
@@ -250,7 +250,7 @@ In addition to the above options, \textit{thesis.cls} supports all of the option
 
 \section{Preliminary Pages}
 
-A number of commands are provided by \textit{thesis.cls} to create the various preliminary pages that must be included in your thesis, e.g, title page, copyright page, abstract, table of contents, et cetra.  The following commands provide information to \textit{thesis.cls} about the contents of your preliminary pages and should be specified before \verb|\begin{document}|.
+A number of commands are provided by \textit{thesis.cls} to create the various preliminary pages that must be included in your thesis, e.g., title page, copyright page, abstract, table of contents, et cetera.  The following commands provide information to \textit{thesis.cls} about the contents of your preliminary pages and should be specified before \verb|\begin{document}|.
 
 \begin{itemize}
     \item \textbf{\textbackslash title}  This command takes a single argument giving the title of your thesis.
@@ -285,7 +285,7 @@ The source code of this document also provides an example of how to add your own
 Please note that \textit{thesis.cls} requires you to denote the various regions of your document using the same conventions as \textit{book.cls}.  The following command denote the beginning of each corresponding region:
 
 \begin{itemize}
-    \item \textbf{\textbackslash frontmatter}  This command denotes the beginning of the preliminary pages, such as the title page, copyright page, table of contents, et cetra.
+    \item \textbf{\textbackslash frontmatter}  This command denotes the beginning of the preliminary pages, such as the title page, copyright page, table of contents, et cetera.
     \item \textbf{\textbackslash mainmatter}  This command denotes the beginning of the main thesis text.  This is where you will write the bulk of your thesis.
     \item \textbf{\textbackslash appendix}  This command denotes the beginning of any appendices that you may wish to add.  Appendices are created just like chapters but are labeled differently.
     \item \textbf{\textbackslash backmatter}  This command denotes the beginning of unnumbered supplementary material.  Notably, this includes your bibliography.

--- a/sample.tex
+++ b/sample.tex
@@ -103,7 +103,7 @@
 % so we use the name \mycopyright instead
 \mycopyright{%
 Copyright by John M. Doe 20\_\_ \\
-All Rights reserved
+All Rights Reserved
 }
 
 % here is an example of a creative commons copyright license


### PR DESCRIPTION
This fixes a few typos in the sample file (not a big deal since most of the text will be replaced by the user anyway).

Also capitalizes 'Reserved' in the example copyright so it matches the CSU sample page. This is already correct in the class file, but I'm guessing a lot of folks will just modify the sample.