### PR TITLE
Remove remreset

### DIFF
--- a/sample.tex
+++ b/sample.tex
@@ -234,8 +234,6 @@ You will need to have several \LaTeX{} packages installed in order for \textit{t
 
     \item \textbf{footmisc}  This package is required for setting up footnotes.
 
-    \item \textbf{remreset}  This package is required for preventing the footnote numbering from resetting after each chapter.
-
     \item \textbf{caption}  This package is required for formatting captions around figures and tables.
 
     \item \textbf{tocloft}  This package is required for formatting the table of contents and similar pages.

--- a/thesis.cls
+++ b/thesis.cls
@@ -168,7 +168,6 @@
 \def\footnoterule{\hrule \@width 2in}
 
 % prevents footnote counter from resetting at new chapter
-\RequirePackage{remreset}
 \@removefromreset{footnote}{chapter}
 
 % Page numbers


### PR DESCRIPTION
The package has been deprecated, and the command \\@removefromreset is part of the LaTeX kernel since the LaTeX release from 2018/04/01. See [here](https://tex.stackexchange.com/questions/468406/latex-error-command-removefromreset-already-defined).